### PR TITLE
Feat/map/location-permission 권한 고지 화면 및 location 권한 확인 로직 작성

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="704127326">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_4_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="androidx.compose.runtime.Composable" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,17 +50,22 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.core:core-ktx:1.4.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
 
     // google map
     implementation 'com.google.maps.android:maps-compose:2.9.1'
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
-    implementation 'androidx.activity:activity-compose:1.3.1'
+    // permission
+    implementation "com.google.accompanist:accompanist-permissions:0.28.0"
+
+    implementation 'androidx.activity:activity-compose:1.6.1'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation "androidx.navigation:navigation-compose:2.5.3"
+
+    // material
     implementation 'androidx.compose.material:material:1.3.1'
     implementation "androidx.compose.material:material-icons-extended:1.3.1"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "com.moyee.android"
-        minSdk 33
+        minSdk 30
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     // timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
+    // dataStore
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+
     // hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -78,6 +79,10 @@ dependencies {
 
     // timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
+
+    // hilt
+    implementation "com.google.dagger:hilt-android:2.44"
+    kapt "com.google.dagger:hilt-compiler:2.44"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,9 @@ dependencies {
     // landscapist-glide
     implementation "com.github.skydoves:landscapist-glide:1.4.7"
 
+    // timber
+    implementation 'com.jakewharton.timber:timber:5.0.1'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
+        android:name=".di.MoyeeApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/moyee/android/MainActivity.kt
+++ b/app/src/main/java/com/moyee/android/MainActivity.kt
@@ -85,7 +85,7 @@ fun MainScreen() {
             startDestination = Screen.Map.route,
             modifier = Modifier.padding(innerPadding)
         ) {
-            composable(Screen.Map.route) { PreviewMapContent() }
+            composable(Screen.Map.route) { MapScreen() }
             composable(Screen.Chat.route) { }
             composable(Screen.Playlist.route) { }
             composable(Screen.User.route) { }

--- a/app/src/main/java/com/moyee/android/MainViewModel.kt
+++ b/app/src/main/java/com/moyee/android/MainViewModel.kt
@@ -1,0 +1,25 @@
+package com.moyee.android
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moyee.android.domain.repository.DataStoreRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val dataStoreRepository: DataStoreRepository,
+) : ViewModel() {
+
+    val isFirstAccess = dataStoreRepository.getFirstAccessStatus()
+        .stateIn(viewModelScope, SharingStarted.Lazily, true)
+
+    fun updateFirstAccessStatus(isFirstAccess: Boolean) {
+        viewModelScope.launch {
+            dataStoreRepository.updateFirstAccessStatus(isFirstAccess)
+        }
+    }
+}

--- a/app/src/main/java/com/moyee/android/MapScreen.kt
+++ b/app/src/main/java/com/moyee/android/MapScreen.kt
@@ -1,5 +1,6 @@
 package com.moyee.android
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.widget.Toast
@@ -63,15 +64,10 @@ fun UserMarker(
     val context = LocalContext.current
     var userImageBitmap by remember { mutableStateOf(context.getBitmap(R.drawable.ic_user_placeholder)) }
 
-    // url 에서 이미지를 로딩 후 비트맵으로 변환
-    Glide.with(context).asBitmap().load(userLocation.imageUrl)
-        .into(object : CustomTarget<Bitmap>() {
-            override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
-                userImageBitmap = resource
-            }
-
-            override fun onLoadCleared(placeholder: Drawable?) {}
-        })
+    context.loadImage(
+        onResourceRoad = { resource -> userImageBitmap = resource },
+        imageUrl = userLocation.imageUrl
+    )
 
     Marker(
         state = MarkerState(position = userLocation.location),
@@ -82,6 +78,27 @@ fun UserMarker(
             imageBitmap = userImageBitmap
         )
     )
+}
+
+/**
+ * url에서 이미지를 로딩하고, 그 이미지를 비트맵으로 변환함
+ *
+ * @param onResourceRoad 반환할 비트맵 이벤트
+ * @param imageUrl 로딩할 이미지 url
+ * */
+fun Context.loadImage(
+    onResourceRoad: (resource: Bitmap) -> Unit,
+    imageUrl: String,
+) {
+    Timber.d("imageUrl=$imageUrl")
+
+    Glide.with(this).asBitmap().load(imageUrl).into(object : CustomTarget<Bitmap>() {
+        override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+            onResourceRoad.invoke(resource)
+        }
+
+        override fun onLoadCleared(placeholder: Drawable?) {}
+    })
 }
 
 /**

--- a/app/src/main/java/com/moyee/android/MapScreen.kt
+++ b/app/src/main/java/com/moyee/android/MapScreen.kt
@@ -10,48 +10,109 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
-import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
-import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.*
+import com.moyee.android.component.MoyeeDialog
 import com.moyee.android.domain.UserLocation
 import com.moyee.android.util.*
+import timber.log.Timber
 
-const val LOCATION_ZOOM = 10f
+private const val LOCATION_ZOOM = 10f
+private val DEFAULT_LOCATION = LatLng(37.0, 126.0)
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun MapScreen() {
+    val context = LocalContext.current
+    val permissionsState =
+        rememberMultiplePermissionsState(permissions = MoyeePermission.FOREGROUND_LOCATION.permissions)
+    var isGrantedForegroundLocationPermission by remember { mutableStateOf(true) }
+
+    OnLifecycleEvent { _, event ->
+        when (event) {
+            Lifecycle.Event.ON_RESUME -> {
+                isGrantedForegroundLocationPermission =
+                    context.checkPermissions(MoyeePermission.FOREGROUND_LOCATION.permissions)
+                Timber.d("isGrantedForegroundLocationPermission=$isGrantedForegroundLocationPermission")
+            }
+
+            else -> {}
+        }
+    }
+
+    if (isGrantedForegroundLocationPermission) {
+        // TODO: 내 위치 값 조회하기
+    } else {
+        ForegroundLocationPermissionCheckDialog(
+            launchForegroundLocationPermissionRequest = { permissionsState.launchMultiplePermissionRequest() }
+        )
+    }
+
+    permissionsState.ProcessPermissionRequest(
+        onAllPermissionGranted = {
+            context.checkPermission(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION).let {isGrantedBackgroundLocationPermission ->
+                Timber.d("isGrantedBackgroundLocationPermission=$isGrantedBackgroundLocationPermission")
+                if (!isGrantedBackgroundLocationPermission)
+                    BackgroundLocationPermissionCheckDialog()
+            }
+        },
+        permissionName = MoyeePermission.FOREGROUND_LOCATION.name
+    )
+
+    MapContent(
+        onMapLoaded = { },
+        myLocation = DEFAULT_LOCATION,
+        otherUsers = emptyList()
+    )
+}
 
 @Composable
 fun MapContent(
-    userLocation: UserLocation,
     onMapLoaded: () -> Unit,
+    myLocation: LatLng,
+    otherUsers: List<UserLocation>,
 ) {
     val context = LocalContext.current
     val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(userLocation.location, LOCATION_ZOOM)
+        position = CameraPosition.fromLatLngZoom(myLocation, LOCATION_ZOOM)
     }
 
     GoogleMap(
         modifier = Modifier.fillMaxSize(),
         cameraPositionState = cameraPositionState,
-        onMapLoaded = onMapLoaded
+        onMapLoaded = onMapLoaded,
+        uiSettings = MapUiSettings(myLocationButtonEnabled = true)
     ) {
         UserMarker(
-            onClick = {
-                // TODO: UserInfo 띄워주기, 새 UI 작성
-                Toast.makeText(context, "user", Toast.LENGTH_SHORT).show()
-                true
-            },
-            userLocation = userLocation,
+            onClick = { true },
+            userLocation = UserLocation(location = myLocation, imageUrl = "https://w.namu.la/s/a5bc19d3232508b1f141def5e3588dd3521ba3aa33ea7cad6caf79c3dbc3c2c64533fa32e669a7e486a1d2af7aab32d4c7e64e3e3a63894e02eeb1a5c9e2b120d020eb77054ffe49caa5d10e6c07a359306ddd0c9dd8631f36a6dfbe3802f3ec"),
             size = 300.dp
         )
+
+        otherUsers.forEach { userLocation ->
+            UserMarker(
+                onClick = {
+                    // TODO: UserInfo 띄워주기, 새 UI 작성
+                    Toast.makeText(context, "I'm user${userLocation.id}!", Toast.LENGTH_SHORT)
+                        .show()
+                    true
+                },
+                userLocation = userLocation,
+                size = 300.dp
+            )
+        }
     }
 }
 
@@ -132,11 +193,22 @@ private fun userLocationIcon(
 }
 
 @Composable
-fun PreviewMapContent() {
-    MapContent(
-        userLocation = UserLocation(
-            1,
-            LatLng(37.0, 126.0),
-            "https://w.namu.la/s/a5bc19d3232508b1f141def5e3588dd3521ba3aa33ea7cad6caf79c3dbc3c2c64533fa32e669a7e486a1d2af7aab32d4c7e64e3e3a63894e02eeb1a5c9e2b120d020eb77054ffe49caa5d10e6c07a359306ddd0c9dd8631f36a6dfbe3802f3ec"
-        ), onMapLoaded = {})
+private fun ForegroundLocationPermissionCheckDialog(
+    launchForegroundLocationPermissionRequest: () -> Unit,
+) {
+    MoyeeDialog(
+        positiveButtonName = stringResource(R.string.confirm),
+        onPositiveButtonClick = { launchForegroundLocationPermissionRequest.invoke() },
+        message = stringResource(R.string.foreground_location_permission_message)
+    )
+}
+
+@Composable
+private fun BackgroundLocationPermissionCheckDialog() {
+    val context = LocalContext.current
+    MoyeeDialog(
+        positiveButtonName = stringResource(R.string.background_location_permission_button_name),
+        onPositiveButtonClick = { context.startSystemSettings() },
+        message = stringResource(R.string.background_location_permission_message)
+    )
 }

--- a/app/src/main/java/com/moyee/android/RequirePermissionScreen.kt
+++ b/app/src/main/java/com/moyee/android/RequirePermissionScreen.kt
@@ -1,0 +1,147 @@
+package com.moyee.android
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.moyee.android.component.MoyeeMainButton
+import com.moyee.android.ui.theme.MoyeeTheme
+import com.moyee.android.util.ProcessPermissionRequest
+import com.moyee.android.util.MoyeePermission
+
+/**
+ * 필수 권한 고지 화면
+ * */
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun RequirePermissionScreen(
+    moyeePermission: MoyeePermission,
+    onAllPermissionsGranted: () -> Unit,
+) {
+    val permissionsState = rememberMultiplePermissionsState(permissions = moyeePermission.permissions)
+
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .padding(48.dp)
+            .fillMaxHeight()
+            .fillMaxWidth(),
+    ) {
+        Column {
+            PermissionHeader()
+            HorizontalBreakLine()
+            PermissionContent()
+        }
+
+        MoyeeMainButton(
+            onClick = { permissionsState.launchMultiplePermissionRequest() },
+            text = stringResource(R.string.okay)
+        )
+    }
+
+    permissionsState.ProcessPermissionRequest(
+        onAllPermissionGranted = { onAllPermissionsGranted.invoke() },
+        permissionName = moyeePermission.permissionName
+    )
+}
+
+// 중단선
+@Composable
+fun HorizontalBreakLine(
+    border: Dp = 1.dp,
+    padding: Dp = 16.dp,
+    color: Color = MaterialTheme.colors.onSurface,
+) {
+    Spacer(
+        modifier = Modifier
+            .height(border)
+            .padding(0.dp, padding)
+            .background(color)
+    )
+}
+
+@Composable
+private fun PermissionHeader() {
+    Text(
+        text = stringResource(R.string.app_permission_access),
+        style = MaterialTheme.typography.h5,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = stringResource(R.string.app_permission_access_description),
+        style = MaterialTheme.typography.body1,
+        modifier = Modifier.padding(start = 16.dp)
+    )
+}
+
+@Composable
+private fun PermissionContent() {
+    Column {
+        Text(
+            text = stringResource(R.string.require_permission),
+            color = MaterialTheme.colors.primary,
+            style = MaterialTheme.typography.body1,
+        )
+        PermissionList()
+    }
+}
+
+@Composable
+private fun PermissionList() {
+    listOf(
+        Pair(R.string.location_info, R.string.location_info_permission_description),
+        Pair(R.string.notification, R.string.notification_permission_description),
+        Pair(R.string.photo, R.string.photo_permission_description)
+    ).forEach { (permissionName, description) ->
+        PermissionItem(
+            permissionNameResourceId = permissionName,
+            descriptionResourceId = description
+        )
+    }
+}
+
+@Composable
+private fun PermissionItem(
+    @StringRes permissionNameResourceId: Int,
+    @StringRes descriptionResourceId: Int,
+) {
+    Column {
+        Text(
+            text = "· ${stringResource(id = permissionNameResourceId)}",
+            style = MaterialTheme.typography.body1
+        )
+        Text(
+            text = stringResource(id = descriptionResourceId),
+            style = MaterialTheme.typography.caption,
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun PreviewPermissionList() {
+    MoyeeTheme {
+        PreviewPermissionList()
+    }
+}
+
+@Composable
+@Preview
+private fun PreviewPermissionItem() {
+    MoyeeTheme {
+        PermissionItem(
+            permissionNameResourceId = R.string.photo,
+            descriptionResourceId = R.string.photo_permission_description
+        )
+    }
+}

--- a/app/src/main/java/com/moyee/android/component/Button.kt
+++ b/app/src/main/java/com/moyee/android/component/Button.kt
@@ -1,0 +1,76 @@
+package com.moyee.android.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.moyee.android.ui.theme.MoyeeTheme
+
+@Composable
+fun MoyeeMainButton(
+    onClick: () -> Unit,
+    text: String,
+) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(50)
+    ) {
+        Text(text = text)
+    }
+}
+
+@Composable
+fun MoyeeSubButton(
+    onClick: () -> Unit,
+    text: String,
+) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = MaterialTheme.colors.secondaryVariant
+        ),
+        shape = RoundedCornerShape(50)
+    ) {
+        Text(text = text)
+    }
+}
+
+@Composable
+fun MoyeeTextButton(
+    onClick: () -> Unit,
+    text: String,
+) {
+    TextButton(onClick = onClick) {
+        Text(
+            text = text,
+            color = MaterialTheme.colors.secondaryVariant
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun PreviewMoyeeMainButton() {
+    MoyeeTheme {
+        MoyeeMainButton(onClick = {}, text = "확인")
+    }
+}
+
+@Composable
+@Preview
+private fun PreviewMoyeeSubButton() {
+    MoyeeTheme {
+        MoyeeSubButton(onClick = {}, text = "화깅")
+    }
+}
+
+@Composable
+@Preview
+private fun PreviewMoyeeTextButton() {
+    MoyeeTheme {
+        MoyeeTextButton(onClick = {}, text = "화귄?")
+    }
+}

--- a/app/src/main/java/com/moyee/android/component/Dialog.kt
+++ b/app/src/main/java/com/moyee/android/component/Dialog.kt
@@ -10,9 +10,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.moyee.android.R
+import com.moyee.android.ui.theme.MoyeeTheme
 import com.moyee.android.ui.theme.Purple700
+import com.moyee.android.util.startSystemSettings
 
 // 직접 접근하지 말고, BaseDialog를 구현한 MoyeeDialog를 사용할 것
 @Composable
@@ -79,11 +85,63 @@ fun MoyeeDialog(
             Row {
                 if (negativeButtonName != null && onNegativeButtonClick != null) {
                     MoyeeTextButton(onClick = onNegativeButtonClick, text = negativeButtonName)
-                    Spacer(modifier = Modifier.weight(1f))
                 }
 
+                Spacer(modifier = Modifier.weight(1f))
                 MoyeeSubButton(onClick = onPositiveButtonClick, text = positiveButtonName)
             }
         }
+    }
+}
+
+/**
+ * 필수 권한 거부시 띄우는 다이얼로그
+ *
+ * @param permissionName 거부 당한 권한 이름
+ * */
+@Composable
+fun PermissionDeniedDialog(
+    onConfirm: () -> Unit,
+    permissionName: String,
+) {
+    MoyeeDialog(
+        positiveButtonName = stringResource(id = R.string.confirm),
+        onPositiveButtonClick = onConfirm,
+        message = stringResource(R.string.permission_denied_message, permissionName)
+    )
+}
+
+/**
+ * 권한 2번 거부/다시 묻지 않기 체크 후 거부시 띄우는 다이얼로그, 확인 버튼 클릭시 직접 안드로이드 설정창을 띄워 줌
+ * */
+@Composable
+fun CheckPermissionInSystemSettingsDialog() {
+    val context = LocalContext.current
+
+    MoyeeDialog(
+        positiveButtonName = stringResource(id = R.string.confirm),
+        onPositiveButtonClick = { context.startSystemSettings() }
+    ) {
+        Column {
+            Text(
+                text = stringResource(id = R.string.permission_system_settings_message),
+                style = MaterialTheme.typography.body1
+            )
+            Spacer(modifier = Modifier.padding(bottom = 16.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewMoyeeDialog() {
+    MoyeeTheme {
+        MoyeeDialog(
+            positiveButtonName = "화긴",
+            onPositiveButtonClick = {},
+            message = "대충 이런저런 메세지예요.dsfsdfdsfsadffsfdfs",
+            negativeButtonName = "ㄴㄴ",
+            onNegativeButtonClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/moyee/android/component/Dialog.kt
+++ b/app/src/main/java/com/moyee/android/component/Dialog.kt
@@ -1,0 +1,89 @@
+package com.moyee.android.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.moyee.android.ui.theme.Purple700
+
+// 직접 접근하지 말고, BaseDialog를 구현한 MoyeeDialog를 사용할 것
+@Composable
+private fun MoyeeBaseDialog(
+    onCloseRequest: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    Dialog(onDismissRequest = { onCloseRequest?.invoke() }) {
+        Surface(
+            color = Color.Transparent,
+            modifier = Modifier.width(500.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = Purple700,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .padding(16.dp, 24.dp)
+            ) {
+                content.invoke()
+            }
+        }
+    }
+}
+
+/**
+ * 앱 다이얼로그
+ *
+ * @param onCloseRequest 다이얼로그 이외 배경을 클릭 시에 처리하는 이벤트 (ex: 다이얼로그 숨기기)
+ * @param positiveButtonName 예/완료 등 메세지에 대한 긍정적인 버튼의 text 값
+ * @param onPositiveButtonClick positiveButton의 클릭 이벤트
+ * @param negativeButtonName 아니오/취소 등 메세지에 대한 부정적인 버튼의 text 값, 사용시에 이벤트 값도 함께 전달해야 함
+ * @param onNegativeButtonClick negativeButton의 클릭 이벤트
+ * @param title 다이얼로그 제목
+ * @param message 다이얼로그 메세지
+ * @param content 일반 메세지 이외 커스텀시 사용
+ * */
+@Composable
+fun MoyeeDialog(
+    onCloseRequest: (() -> Unit)? = null,
+    positiveButtonName: String,
+    onPositiveButtonClick: () -> Unit,
+    negativeButtonName: String? = null,
+    onNegativeButtonClick: (() -> Unit)? = null,
+    title: String? = null,
+    message: String? = null,
+    content: (@Composable () -> Unit)? = null,
+) {
+    MoyeeBaseDialog(onCloseRequest = onCloseRequest) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            title?.let { Text(text = it) }
+
+            message?.let {
+                Text(
+                    text = it,
+                    color = MaterialTheme.colors.onSecondary,
+                    style = MaterialTheme.typography.body1
+                )
+            } ?: run { content?.invoke() }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row {
+                if (negativeButtonName != null && onNegativeButtonClick != null) {
+                    MoyeeTextButton(onClick = onNegativeButtonClick, text = negativeButtonName)
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+
+                MoyeeSubButton(onClick = onPositiveButtonClick, text = positiveButtonName)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/moyee/android/di/DataStoreModule.kt
+++ b/app/src/main/java/com/moyee/android/di/DataStoreModule.kt
@@ -1,0 +1,30 @@
+package com.moyee.android.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val SETTINGS_PREFERENCES = "setting_preferences"
+
+internal val FIRST_ACCESS_STATUS = booleanPreferencesKey("firstAccessStatus")
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DataStoreModule {
+
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile(SETTINGS_PREFERENCES) }
+        )
+}

--- a/app/src/main/java/com/moyee/android/di/MoyeeApp.kt
+++ b/app/src/main/java/com/moyee/android/di/MoyeeApp.kt
@@ -1,0 +1,7 @@
+package com.moyee.android.di
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MoyeeApp : Application()

--- a/app/src/main/java/com/moyee/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/moyee/android/di/RepositoryModule.kt
@@ -1,0 +1,16 @@
+package com.moyee.android.di
+
+import com.moyee.android.domain.repository.DataStoreRepository
+import com.moyee.android.domain.repository.DataStoreRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+interface RepositoryModule {
+
+    @Binds
+    fun bindsDataStoreRepository(dataStoreRepositoryImpl: DataStoreRepositoryImpl): DataStoreRepository
+}

--- a/app/src/main/java/com/moyee/android/domain/UserLocation.kt
+++ b/app/src/main/java/com/moyee/android/domain/UserLocation.kt
@@ -7,7 +7,7 @@ import com.google.android.gms.maps.model.LatLng
  * TODO: 서버단과 상의 후 데이터 클래스 변경 예정
  * */
 data class UserLocation(
-    val id: Int,
+    val id: Int? = null,
     val location: LatLng,
     val imageUrl: String
 )

--- a/app/src/main/java/com/moyee/android/domain/repository/DataStoreRepository.kt
+++ b/app/src/main/java/com/moyee/android/domain/repository/DataStoreRepository.kt
@@ -1,0 +1,10 @@
+package com.moyee.android.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface DataStoreRepository {
+
+    suspend fun updateFirstAccessStatus(isFirstAccess: Boolean)
+
+    fun getFirstAccessStatus(): Flow<Boolean>
+}

--- a/app/src/main/java/com/moyee/android/domain/repository/DataStoreRepositoryImpl.kt
+++ b/app/src/main/java/com/moyee/android/domain/repository/DataStoreRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.moyee.android.domain.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.moyee.android.di.FIRST_ACCESS_STATUS
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class DataStoreRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+) : DataStoreRepository {
+
+    override suspend fun updateFirstAccessStatus(isFirstAccess: Boolean) {
+        dataStore.edit { settings ->
+            settings[FIRST_ACCESS_STATUS] = isFirstAccess
+        }
+    }
+
+    override fun getFirstAccessStatus(): Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[FIRST_ACCESS_STATUS] ?: true
+    }
+}

--- a/app/src/main/java/com/moyee/android/util/LifecycleExt.kt
+++ b/app/src/main/java/com/moyee/android/util/LifecycleExt.kt
@@ -1,0 +1,25 @@
+package com.moyee.android.util
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+
+@Composable
+fun OnLifecycleEvent(onEvent: (owner: LifecycleOwner, event: Lifecycle.Event) -> Unit) {
+    val eventHandler = rememberUpdatedState(onEvent)
+    val lifecycleOwner = rememberUpdatedState(LocalLifecycleOwner.current)
+
+    DisposableEffect(lifecycleOwner.value) {
+        val lifecycle = lifecycleOwner.value.lifecycle
+        val observer = LifecycleEventObserver { owner, event ->
+            eventHandler.value(owner, event)
+        }
+
+        lifecycle.addObserver(observer)
+        onDispose {
+            lifecycle.removeObserver(observer)
+        }
+    }
+}

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -28,7 +28,7 @@ fun Context.checkPermissions(permissions: List<String>): Boolean =
  * @return [Boolean] 권한 허용 여부
  * */
 fun Context.checkPermission(permission: String): Boolean =
-    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_DENIED
+    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 
 /**
  * 안드로이드 시스템 설정 앱을 실행함

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -8,22 +8,22 @@ import android.provider.Settings
 import androidx.core.content.ContextCompat
 
 /**
- * 권한 체크
+ * 다중 권한 체크
  *
- * @param moyeePermission 체크할 권한
- * @return [String] 허용되지 않은 권한의 이름을 반환, 모두 허용되었다면 null
+ * @param permissions 체크할 권한들
+ * @return [Boolean] 권한 허용 여부
  * */
-fun Context.checkPermissions(moyeePermission: MoyeePermission): String? =
-    moyeePermission.run {
-        permissions.forEach { permission ->
-            if (ContextCompat.checkSelfPermission(
-                    this@checkPermissions,
-                    permission
-                ) == PackageManager.PERMISSION_DENIED
-            ) permissionName
-        }
-        null
-    }
+fun Context.checkPermissions(permissions: List<String>): Boolean =
+    permissions.all { permission -> checkPermission(permission) }
+
+/**
+ * 단일 권한 체크
+ *
+ * @param permission 체크할 권한
+ * @return [Boolean] 권한 허용 여부
+ * */
+fun Context.checkPermission(permission: String): Boolean =
+    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_DENIED
 
 /**
  * 안드로이드 시스템 설정 앱을 실행함

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -1,0 +1,47 @@
+package com.moyee.android.util
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.core.content.ContextCompat
+
+/**
+ * 권한 체크
+ *
+ * @param moyeePermission 체크할 권한
+ * @return [String] 허용되지 않은 권한의 이름을 반환, 모두 허용되었다면 null
+ * */
+fun Context.checkPermissions(moyeePermission: MoyeePermission): String? =
+    moyeePermission.run {
+        permissions.forEach { permission ->
+            if (ContextCompat.checkSelfPermission(
+                    this@checkPermissions,
+                    permission
+                ) == PackageManager.PERMISSION_DENIED
+            ) permissionName
+        }
+        null
+    }
+
+/**
+ * 안드로이드 시스템 설정 앱을 실행함
+ * */
+fun Context.startSystemSettings() {
+    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:${packageName}")).apply {
+        addCategory(Intent.CATEGORY_DEFAULT)
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(this)
+    }
+}
+
+enum class MoyeePermission(val permissionName: String, val permissions: List<String>) {
+    LOCATION(
+        "위치",
+        listOf(
+            android.Manifest.permission.ACCESS_FINE_LOCATION,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+    )
+}

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -36,6 +36,38 @@ fun Context.startSystemSettings() {
     }
 }
 
+/**
+ * 권한 허락 여부에 따른 분기 이벤트 처리를 하는 함수로,
+ * 권한을 전부 허용했을 때, 첫 번째 거부, 두 번째 거부시로 나누어져 각각의 이벤트를 처리함
+ *
+ * @param onAllPermissionGranted 모든 권한을 허용했을 때 실행되는 이벤트
+ * @param onFirstDenied 권한을 첫 번째 거부했을 때 실행되는 이벤트, 이벤트를 설정하지 않으면 기본 다이얼로그를 띄움
+ * @param onSecondDenied 권한을 두 번째 거부했을 때 실행되는 이벤트, 이벤트를 설정하지 않으면 기본 다이얼로그를 띄움
+ * @param permissionName 확인할 권한의 이름
+ * */
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun MultiplePermissionsState.ProcessPermissionRequest(
+    onAllPermissionGranted: @Composable () -> Unit,
+    onFirstDenied: (@Composable () -> Unit)? = null,
+    onSecondDenied: (@Composable () -> Unit)? = null,
+    permissionName: String,
+) {
+    when {
+        allPermissionsGranted -> onAllPermissionGranted.invoke()
+
+        shouldShowRationale -> onFirstDenied?.let {
+            PermissionDeniedDialog(
+                onConfirm = { launchMultiplePermissionRequest() },
+                permissionName = permissionName
+            )
+        }
+
+        !allPermissionsGranted && !shouldShowRationale ->
+            onSecondDenied?.let { CheckPermissionInSystemSettingsDialog() }
+    }
+}
+
 enum class MoyeePermission(val permissionName: String, val permissions: List<String>) {
     LOCATION(
         "위치",

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -69,7 +69,7 @@ fun MultiplePermissionsState.ProcessPermissionRequest(
 }
 
 enum class MoyeePermission(val permissionName: String, val permissions: List<String>) {
-    LOCATION(
+    FOREGROUND_LOCATION(
         "위치",
         listOf(
             android.Manifest.permission.ACCESS_FINE_LOCATION,

--- a/app/src/main/java/com/moyee/android/util/PermissionExt.kt
+++ b/app/src/main/java/com/moyee/android/util/PermissionExt.kt
@@ -5,7 +5,12 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.Settings
+import androidx.compose.runtime.Composable
 import androidx.core.content.ContextCompat
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.moyee.android.component.CheckPermissionInSystemSettingsDialog
+import com.moyee.android.component.PermissionDeniedDialog
 
 /**
  * 다중 권한 체크
@@ -29,7 +34,10 @@ fun Context.checkPermission(permission: String): Boolean =
  * 안드로이드 시스템 설정 앱을 실행함
  * */
 fun Context.startSystemSettings() {
-    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:${packageName}")).apply {
+    Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.parse("package:${packageName}")
+    ).apply {
         addCategory(Intent.CATEGORY_DEFAULT)
         flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(this)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,19 @@
 <resources>
     <string name="app_name">Moyee</string>
+
+    <string name="app_permission_access">앱 권한 접근 안내</string>
+    <string name="app_permission_access_description">Moyee 앱을 사용하기 위해서는 아래의 권한이 필요해요!</string>
+    <string name="require_permission">필수 접근 권한</string>
+    <string name="optional_permission">선택 접근 권한</string>
+    <string name="location_info">위치 정보</string>
+    <string name="location_info_permission_description">내 위치 기반 덕질 메이트 정보 조회</string>
+    <string name="notification">알림</string>
+    <string name="notification_permission_description">채팅</string>
+    <string name="photo">사진</string>
+    <string name="photo_permission_description">프로필 사진 등록, 채팅 중 이미지 보내기</string>
+    <string name="okay">알았어요!</string>
+    <string name="confirm">확인</string>
+    <string name="permission_denied_message">%1$s 권한을 허용하지 않으면 해당 기능을 이용할 수 없어요! 권한을 허용해주세요.</string>
+    <string name="permission_system_settings_message">권한 허용 안 하면 앱 이용 못함 ㅅㄱ\n설정창에서 아래 권한들 허락 좀 해주세요 ㅠㅠ</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,5 +15,8 @@
     <string name="confirm">확인</string>
     <string name="permission_denied_message">%1$s 권한을 허용하지 않으면 해당 기능을 이용할 수 없어요! 권한을 허용해주세요.</string>
     <string name="permission_system_settings_message">권한 허용 안 하면 앱 이용 못함 ㅅㄱ\n설정창에서 아래 권한들 허락 좀 해주세요 ㅠㅠ</string>
+    <string name="background_location_permission_message">친구들에게 내 위치를 공유하기 위해서는 위치 권한을 항상 허용으로 지정해야 돼요. Moyee -> 권한 -> 위치를 항상 허용으로 변경해주세요!</string>
+    <string name="background_location_permission_button_name">항상 허용으로 바꾸러 가기</string>
+    <string name="foreground_location_permission_message">내 위치를 지도에 표시하기 위해서는 위치 권한을 허용해야 돼요! 위치 권한을 허용해주세요.</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -12,4 +12,5 @@ plugins {
     id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
+    id 'com.google.dagger.hilt.android' version '2.44' apply false
 }


### PR DESCRIPTION
- 필수 및 선택적 권한 고지 화면 구현
  - 앱 최초 접근시에만 띄워주기 때문에 dataStore을 통한 최초 접근 확인 로직 구현
- MapScreen에서 Foreground/Background Location Permission 확인 로직 추가
- 권한 관련 utility: 다이얼로그는 `Dialog.kt`, 확장 함수는 `PermissionExt.kt` 파일에 정의됨
  - 권한 확인 로직 시행시 전반적으로 쓰이는 기본 권한 요구 다이얼로그 구현 (`CheckPermissionInSystemSettingsDialog`, `PermissionDeniedDialog`)
  - 단일 및 다중 권한 체크 확장 함수 추가 (`checkPermission`, `checkPermissions`)
  - 권한이 2번 거부되거나 Background Location 권한을 확인할 때, 설정 앱으로 이동하는 확장 함수 추가 (`startSystemSettings`)
  - 권한 허락 및 거부 여부에 따른 이벤트 분기 처리를 돕는 확장 함수 추가 (`ProcessPermissionRequest`)

드디어 끝났다.. 🥹